### PR TITLE
Add README files for module folders

### DIFF
--- a/combinatorialCircuits/ALU/README.md
+++ b/combinatorialCircuits/ALU/README.md
@@ -1,0 +1,5 @@
+# Arithmetic Logic Unit
+
+A simple 8‑bit ALU supporting operations such as add, subtract, increment, bitwise logic and rotates. The Verilog source `alu.v` defines the opcodes and combinational logic.
+
+Modify or extend the opcodes to experiment with additional functions.

--- a/combinatorialCircuits/Comparator/README.md
+++ b/combinatorialCircuits/Comparator/README.md
@@ -1,0 +1,5 @@
+# Comparator
+
+Parameterizable magnitude comparator with a simple test bench. Adjust the `N` parameter to set the bit width.
+
+Simulation can be run with the `run_comparator.tcl` script provided in this folder.

--- a/combinatorialCircuits/Decoders/4to16binary/README.md
+++ b/combinatorialCircuits/Decoders/4to16binary/README.md
@@ -1,0 +1,9 @@
+# 4‑to‑16 Binary Decoder
+
+Implements a 4‑bit input to 16‑line output binary decoder. The `decoder_tb.v` test bench exercises all input combinations.
+
+Run the ModelSim script to compile and simulate:
+
+```bash
+vsim -do run_decoder.tcl
+```

--- a/combinatorialCircuits/Decoders/Nbit/README.md
+++ b/combinatorialCircuits/Decoders/Nbit/README.md
@@ -1,0 +1,5 @@
+# Parameterized N‑bit Decoder
+
+The `nbitdecoder.v` module generates a `2**N` output decoder where `N` is configurable. The accompanying test bench verifies basic functionality.
+
+Use `run_decoder.tcl` with ModelSim to build and run the design.

--- a/combinatorialCircuits/Decoders/README.md
+++ b/combinatorialCircuits/Decoders/README.md
@@ -1,0 +1,8 @@
+# Decoders
+
+Two example decoder implementations:
+
+* `4to16binary/` – Fixed 4‑to‑16 binary decoder
+* `Nbit/` – Parameterized N‑bit decoder
+
+Both folders include ModelSim scripts to build and run the test benches.

--- a/combinatorialCircuits/README.md
+++ b/combinatorialCircuits/README.md
@@ -1,0 +1,13 @@
+# Combinatorial Circuits
+
+Examples of arithmetic and logic blocks that do not rely on clock edges. Folders in this directory include adders, subtractors, encoders/decoders, comparators and a simple ALU. Most subdirectories provide ModelSim scripts so you can quickly simulate each module.
+
+```
+ALU/            - 8‑bit arithmetic logic unit
+adders/         - Half, full and tree adders
+subtractors/    - Half and full subtractor examples
+Comparator/     - Parameterized magnitude comparator
+Decoders/       - Binary and parameterized decoders
+```
+
+Navigate to an individual folder and run its simulation script to see waveforms.

--- a/combinatorialCircuits/adders/README.md
+++ b/combinatorialCircuits/adders/README.md
@@ -1,0 +1,9 @@
+# Adders
+
+Collection of simple adder implementations used for learning basic arithmetic hardware design.
+
+* `halfadder/` – Half adder structural and behavioral models
+* `fulladder/` – Full adder with test bench
+* `treeadder/` – Four‑bit tree adder example (includes existing README)
+
+Each folder contains Verilog sources and a ModelSim TCL script (`run_*.tcl`) to compile and simulate the design.

--- a/combinatorialCircuits/adders/fulladder/README.md
+++ b/combinatorialCircuits/adders/fulladder/README.md
@@ -1,0 +1,11 @@
+# Full Adder
+
+Implements a single‑bit full adder. The test bench `full_adder_tb.v` applies sample vectors and prints the sum and carry outputs.
+
+To run the simulation in ModelSim:
+
+```bash
+vsim -do run_fulladder.tcl  # adjust script name if needed
+```
+
+The design can be extended or instantiated in larger adders.

--- a/combinatorialCircuits/adders/halfadder/README.md
+++ b/combinatorialCircuits/adders/halfadder/README.md
@@ -1,0 +1,9 @@
+# Half Adder
+
+Contains simple half‑adder implementations demonstrating both structural and behavioral styles. Test benches are provided for functional verification.
+
+Example simulation (ModelSim):
+
+```bash
+vsim -do run_halfadder.tcl
+```

--- a/combinatorialCircuits/subtractors/README.md
+++ b/combinatorialCircuits/subtractors/README.md
@@ -1,0 +1,9 @@
+# Subtractors
+
+Verilog designs for half and full subtractors. Example test benches illustrate the difference between borrowing and no borrow.
+
+Files:
+- `Subtractor.v` – Basic single‑bit subtractor
+- `full_subtractor.v` – Full subtractor with borrow in/out
+
+Use the provided test benches (`half_subtractor_tb.v`, `full_subtractor_Testbench.v`) to simulate in ModelSim.

--- a/schematics_basic_gates/README.md
+++ b/schematics_basic_gates/README.md
@@ -1,0 +1,5 @@
+# Basic Gate Schematics
+
+Cadence schematic files and test benches for standard logic gates (AND, OR, NAND, NOR, XOR, XNOR) as well as small example circuits such as inverters and ring oscillators.
+
+These directories are intended for use with Cadence Virtuoso. They include library data (`data.dm`, `schematic/`, `symbol/`) plus test benches for simulation.

--- a/sequentialCircuits/README.md
+++ b/sequentialCircuits/README.md
@@ -1,0 +1,5 @@
+# Sequential Circuits
+
+Designs that rely on clock edges or sequential behavior. The `clockGenAndDist` folder contains notes and examples for generating and distributing clock signals.
+
+Refer to that subfolder's README for detailed information.

--- a/verilogBasics/README.md
+++ b/verilogBasics/README.md
@@ -1,0 +1,11 @@
+# Verilog Basics
+
+This directory contains small Verilog programs that demonstrate key language features such as datatypes, operators, bit slicing and replication. Each `.v` file focuses on a specific concept so you can experiment with the syntax.
+
+To try the examples with ModelSim:
+
+```bash
+vsim -do run_sim.tcl
+```
+
+The `run_sim.tcl` script compiles `vectorbitslicing.v` and runs a short simulation. You can modify the script to compile any of the other examples.


### PR DESCRIPTION
## Summary
- add usage notes to `verilogBasics`
- document subdirectories in `combinatorialCircuits`
- add README files for adders, subtractors, decoder examples and ALU
- describe Cadence schematics and sequential circuits

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685f265e05b8832c84fa1df87eed61e9